### PR TITLE
음식점 상세페이지 개선

### DIFF
--- a/src/components/RatingStar.tsx
+++ b/src/components/RatingStar.tsx
@@ -18,39 +18,41 @@ export default function RatingStar({
   const borderColor = "#71717a";
 
   return (
-    <div className="flex flex-row gap-1">
-      {new Array(5).fill(0).map((_, index) => {
-        if (rating - index >= 1) {
-          return (
-            <Star
-              size={size}
-              key={index}
-              fill={fill}
-              color={borderColor}
-              strokeWidth={strokeWidth}
-            />
-          );
-        } else if (rating - index < 1 && rating - index > 0) {
-          return (
-            <StarHalf
-              size={size}
-              key={index}
-              fill={fill}
-              color={borderColor}
-              strokeWidth={strokeWidth}
-            />
-          );
-        } else {
-          return (
-            <Star
-              size={size}
-              key={index}
-              strokeWidth={strokeWidth}
-              color={borderColor}
-            />
-          );
-        }
-      })}
+    <div className="flex flex-row gap-2 items-center">
+      <div className="flex flex-row gap-1">
+        {new Array(5).fill(0).map((_, index) => {
+          if (rating - index >= 1) {
+            return (
+              <Star
+                size={size}
+                key={index}
+                fill={fill}
+                color={borderColor}
+                strokeWidth={strokeWidth}
+              />
+            );
+          } else if (rating - index < 1 && rating - index > 0) {
+            return (
+              <StarHalf
+                size={size}
+                key={index}
+                fill={fill}
+                color={borderColor}
+                strokeWidth={strokeWidth}
+              />
+            );
+          } else {
+            return (
+              <Star
+                size={size}
+                key={index}
+                strokeWidth={strokeWidth}
+                color={borderColor}
+              />
+            );
+          }
+        })}
+      </div>
 
       <span className="text-neutral-500 text-sm">
         {showScore ? rating.toFixed(digit) : ""}


### PR DESCRIPTION
# 변경사항
## 상세페이지 관련
- 상세페이지에서 별점 평균 보이게 변경
<img width="589" height="342" alt="스크린샷 2025-07-28 11 27 30" src="https://github.com/user-attachments/assets/f0523e35-c5fd-43c2-8fb2-05c8faa4d205" />

- 비로그인상태에서 리뷰 작성 창 비활성화
<img width="589" height="201" alt="스크린샷 2025-07-28 11 28 02" src="https://github.com/user-attachments/assets/105331e5-06af-443a-8877-89d8116d7bd7" />

- 주소 클릭 시 카카오맵 세부정보 페이지로 연결되도록 변경
<img width="589" height="284" alt="스크린샷 2025-07-28 11 28 13" src="https://github.com/user-attachments/assets/875d35bf-910f-4950-a27f-c4889582cb76" />

## `RatingStar` 컴포넌트 관련
- 해당 컴포넌트에서 별 아이콘과 점수 사이 간격 변경
- 점수 텍스트 세로 가운데 정렬