### PR TITLE
음식점 상세페이지에서 메뉴 볼 수 있도록 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "yogiyum",
       "version": "0.0.0",
       "dependencies": {
+        "@radix-ui/react-collapsible": "^1.1.11",
         "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-select": "^2.2.5",
         "@radix-ui/react-slot": "^1.2.3",
@@ -1112,6 +1113,36 @@
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-collapsible": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collapsible/-/react-collapsible-1.1.11.tgz",
+      "integrity": "sha512-2qrRsVGSCYasSz1RFOorXwl0H7g7J1frQtgpQgYrt+MOidtPAINHn9CPovQXb83r8ahapdx3Tu0fa/pdFFSdPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-use-layout-effect": "1.1.1"
       },
       "peerDependencies": {
         "@types/react": "*",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@radix-ui/react-collapsible": "^1.1.11",
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-select": "^2.2.5",
     "@radix-ui/react-slot": "^1.2.3",

--- a/src/components/MenuCard.tsx
+++ b/src/components/MenuCard.tsx
@@ -1,0 +1,27 @@
+import type { Menu } from "@/entities/menu";
+import { Card } from "./ui/card";
+
+interface Props {
+  menu: Menu;
+}
+
+export default function MenuCard(props: Props) {
+  return (
+    <Card className="flex flex-row gap-4 p-4 bg-neutral-50">
+      {/* 메뉴 카드 이미지 */}
+      {props.menu.imageUrl && (
+        <img
+          src={props.menu.imageUrl.toString()}
+          className="aspect-square object-cover h-20 rounded-sm"
+        />
+      )}
+
+      {/* 메뉴 카드 우측 부분 */}
+      <div className="flex flex-col flex-1 gap-1">
+        <div className="font-bold text-lg">{props.menu.name}</div>
+        <div className="text-sm text-neutral-500">{props.menu.description}</div>
+        <div className="font-bold text-end">{props.menu.price}</div>
+      </div>
+    </Card>
+  );
+}

--- a/src/components/MenuCardSection.tsx
+++ b/src/components/MenuCardSection.tsx
@@ -1,0 +1,53 @@
+import type { Menu } from "@/entities/menu";
+import MenuCard from "./MenuCard";
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "./ui/collapsible";
+import { useState } from "react";
+import { Button } from "./ui/button";
+import { ChevronsUpDownIcon } from "lucide-react";
+
+interface Props {
+  menus: Menu[];
+}
+
+export default function MenuCardSection(props: Props) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  return (
+    <section>
+      <Collapsible
+        open={isOpen}
+        onOpenChange={setIsOpen}
+        className="flex flex-col gap-4"
+      >
+        <header className="flex justify-between items-center">
+          <h2 className="text-2xl font-bold">메뉴</h2>
+          <CollapsibleTrigger asChild>
+            <Button variant="ghost" size="icon">
+              <ChevronsUpDownIcon />
+            </Button>
+          </CollapsibleTrigger>
+        </header>
+
+        <div className="flex flex-col gap-2">
+          <div className="grid grid-cols-2 gap-2">
+            {props.menus.slice(0, 2).map((menu, idx) => (
+              <MenuCard key={idx} menu={menu} />
+            ))}
+          </div>
+
+          <CollapsibleContent>
+            <div className="grid grid-cols-2 gap-2">
+              {props.menus.slice(2).map((menu, idx) => (
+                <MenuCard key={idx} menu={menu} />
+              ))}
+            </div>
+          </CollapsibleContent>
+        </div>
+      </Collapsible>
+    </section>
+  );
+}

--- a/src/components/ui/collapsible.tsx
+++ b/src/components/ui/collapsible.tsx
@@ -1,0 +1,31 @@
+import * as CollapsiblePrimitive from "@radix-ui/react-collapsible"
+
+function Collapsible({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.Root>) {
+  return <CollapsiblePrimitive.Root data-slot="collapsible" {...props} />
+}
+
+function CollapsibleTrigger({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleTrigger>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleTrigger
+      data-slot="collapsible-trigger"
+      {...props}
+    />
+  )
+}
+
+function CollapsibleContent({
+  ...props
+}: React.ComponentProps<typeof CollapsiblePrimitive.CollapsibleContent>) {
+  return (
+    <CollapsiblePrimitive.CollapsibleContent
+      data-slot="collapsible-content"
+      {...props}
+    />
+  )
+}
+
+export { Collapsible, CollapsibleTrigger, CollapsibleContent }

--- a/src/entities/menu.ts
+++ b/src/entities/menu.ts
@@ -1,0 +1,19 @@
+export interface Menu {
+  /// 메뉴 고유 id
+  id: number;
+
+  /// 식당 id
+  restaurantId: number;
+
+  /// 메뉴명
+  name: string;
+
+  /// 메뉴 소개
+  description: string;
+
+  /// 메뉴 가격
+  price: string;
+
+  /// 메뉴 이미지 URL
+  imageUrl?: URL;
+}

--- a/src/pages/RestaurantDetail.tsx
+++ b/src/pages/RestaurantDetail.tsx
@@ -1,10 +1,12 @@
+import MenuCard from "@/components/MenuCard";
+import MenuCardSection from "@/components/MenuCardSection";
 import RatingStar from "@/components/RatingStar";
 import RestaurantCategoryBadge from "@/components/RestaurantCategoryBadge";
 import ReviewCard from "@/components/ReviewCard";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-
 import { Textarea } from "@/components/ui/textarea";
+import type { Menu } from "@/entities/menu";
 import { RestaurantCategory, type Restaurant } from "@/entities/restaurant";
 import type { Review } from "@/entities/review";
 import supabase from "@/lib/supabase";
@@ -28,6 +30,7 @@ export default function RestaurantDetailPage() {
   const { id } = useParams();
   const [restaurant, setRestaurant] = useState<RestaurantWithExtendInfo>();
   const [reviews, setReviews] = useState<ReviewWithNickname[]>();
+  const [menus, setMenus] = useState<Menu[]>();
   const [reviewRating, setReviewRating] = useState<number>(0);
   const [reviewContent, setReviewContent] = useState<string>("");
   const [isLogin, setIsLogin] = useState<boolean>(false);
@@ -86,6 +89,29 @@ export default function RestaurantDetailPage() {
       });
   };
 
+  const getMenus = () => {
+    supabase
+      .from("menus")
+      .select("*")
+      .eq("restaurant_id", id)
+      .then(({ data }) => {
+        if (!data) return;
+
+        const newData = data.map((menu) => {
+          return {
+            id: menu.id,
+            restaurantId: menu.restaurant_id,
+            name: menu.menu,
+            price: menu.menu_price,
+            imageUrl: menu.menu_img ? new URL(menu.menu_img) : undefined,
+            description: menu.menu_desc,
+          };
+        });
+
+        setMenus(newData);
+      });
+  };
+
   const getReviews = () => {
     supabase
       .from("reviews")
@@ -114,6 +140,7 @@ export default function RestaurantDetailPage() {
 
   useEffect(() => {
     getRestaurantInfo();
+    getMenus();
     getReviews();
   }, [id]);
 
@@ -194,6 +221,9 @@ export default function RestaurantDetailPage() {
           </dl>
         </div>
       </div>
+
+      {menus && menus.length > 0 && <MenuCardSection menus={menus} />}
+
       {/* 리뷰 부분 */}
       <div className="flex flex-col gap-4">
         <h2 className="text-2xl font-bold">리뷰</h2>


### PR DESCRIPTION
# 변경 사항
- 메뉴를 보여주는 `MenuCard` 컴포넌트 추가
- 메뉴 목록을 보여주는 `MenuCardSection` 컴포넌트 추가
- 음식점 상세 페이지에서 메뉴가 있을 때 메뉴를 보여주도록 추가
<img width="589" height="387" alt="스크린샷 2025-07-28 14 25 21" src="https://github.com/user-attachments/assets/47c5bc39-6047-412c-9f8a-f23a7a255f20" />
