### PR TITLE
음식점 목록 배열 시 `flex` 대신 `grid`를 사용하도록 변경

### DIFF
--- a/src/components/RestaurantCard.tsx
+++ b/src/components/RestaurantCard.tsx
@@ -43,7 +43,7 @@ export default function RestaurantCard({
   };
 
   return (
-    <Card className="w-full sm:w-[calc(50%-0.75rem)] md:w-[calc(50%-0.4rem)] relative flex flex-col rounded-xl overflow-hidden bg-[#fffaf6] transition-transform duration-100 hover:scale-[1.02] p-3 gap-3 ">
+    <Card className="w-full relative flex flex-col rounded-xl overflow-hidden bg-[#fffaf6] transition-transform duration-100 hover:scale-[1.02] p-3 gap-3 ">
       {/* 인기 강조 배경 배지 */}
       {isPopular && (
         <div className="absolute top-2 left-2 px-2 py-1 bg-orange-500 text-white text-xs font-extrabold rounded-md shadow-lg z-20 ">

--- a/src/pages/LikedRestaurantsPage.tsx
+++ b/src/pages/LikedRestaurantsPage.tsx
@@ -95,7 +95,7 @@ export default function LikedRestaurantsPage() {
           </p>
         </div>
       ) : (
-        <div className="flex flex-wrap gap-3 justify-center">
+        <div className="grid grid-cols-1 md:grid-cols-2 gap-3 justify-center">
           {restaurants.map((restaurant, idx) => (
             <RestaurantCard
               key={idx}

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -200,7 +200,7 @@ export default function MainPage() {
               </p>
             </div>
           ) : restaurants && restaurants.length > 0 ? (
-            <div className="flex flex-wrap gap-3">
+            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
               {restaurants.map((item, idx) => (
                 <RestaurantCard
                   key={idx}


### PR DESCRIPTION
# 변경 사항
- 음식점 목록 배열 시 `flex` 대신 `grid`를 사용하도록 변경 (음식점 홀수 개 배치 시 가운데 말고 한쪽 끝에 들어가도록 변경됨)
<img width="589" height="697" alt="스크린샷 2025-07-29 15 22 57" src="https://github.com/user-attachments/assets/ccc3cad9-d198-47c1-bdfd-75f841dbd4e8" />

- 화면 크기 `md` 이하일 때 한 줄, 그 외에는 두 줄로 설정
