### PR TITLE
음식점 상세페이지에 지도 이미지 추가 외

### DIFF
--- a/src/components/CommentCard.tsx
+++ b/src/components/CommentCard.tsx
@@ -1,58 +1,61 @@
 import { PencilIcon, Trash2Icon } from "lucide-react";
 import { Button } from "./ui/button";
 import { Card } from "./ui/card";
-import type { Comment } from "@/entities/comment";
 import RatingStar from "./RatingStar";
 import { useState } from "react";
 
 interface Props {
-    comment: {
-        id: number;
-        rating: number;
-        content: string;
-        user_id: number;
-        restaurant_id: number;
-    };
+  comment: {
+    id: number;
+    rating: number;
+    content: string;
+    user_id: number;
+    restaurant_id: number;
+  };
 }
 
 export default function CommentCard({ comment }: Props) {
-    const [isEditing, setIsEditing] = useState(false);
-    const [editedContent, setEditedContent] = useState(comment.content);
-    return (
-        <Card className="flex flex-col gap-4 bg-white rounded-md text-black p-4">
-            <header className="flex flex-row justify-between items-center">
-                <div className="flex flex-row gap-8 items-center">
-                    {/* 닉네임부분 */}
-                    <span className="text-lg font-bold">{comment.userId}</span>
+  const [isEditing, setIsEditing] = useState(false);
+  const [editedContent, setEditedContent] = useState(comment.content);
+  return (
+    <Card className="flex flex-col gap-4 bg-white rounded-md text-black p-4">
+      <header className="flex flex-row justify-between items-center">
+        <div className="flex flex-row gap-8 items-center">
+          {/* 닉네임부분 */}
+          <span className="text-lg font-bold">{comment.user_id}</span>
 
-                    {/* 별점부분 */}
-                    <RatingStar rating={comment.rating} digit={0} />
-                </div>
+          {/* 별점부분 */}
+          <RatingStar rating={comment.rating} digit={0} />
+        </div>
 
-                <div className="flex flex-row gap-2">
-                    <Button size="icon" variant="secondary" onClick={() => setIsEditing(true)}>
-                        <PencilIcon />
-                    </Button>
+        <div className="flex flex-row gap-2">
+          <Button
+            size="icon"
+            variant="secondary"
+            onClick={() => setIsEditing(true)}
+          >
+            <PencilIcon />
+          </Button>
 
-                    <Button size="icon" variant="destructive">
-                        <Trash2Icon />
-                    </Button>
-                </div>
-            </header>
+          <Button size="icon" variant="destructive">
+            <Trash2Icon />
+          </Button>
+        </div>
+      </header>
 
-            <div className="w-full text-start">
-                {isEditing ? (
-                    <input
-                        className="w-full border rounded p-2"
-                        value={editedContent}
-                        onChange={(e) => setEditedContent(e.target.value)}
-                        onBlur={() => setIsEditing(false)} // 포커스 벗어나면 종료
-                        autoFocus
-                    />
-                ) : (
-                    <p>{editedContent}</p> // 수정된 내용 표시
-                )}
-            </div>
-        </Card>
-    );
+      <div className="w-full text-start">
+        {isEditing ? (
+          <input
+            className="w-full border rounded p-2"
+            value={editedContent}
+            onChange={(e) => setEditedContent(e.target.value)}
+            onBlur={() => setIsEditing(false)} // 포커스 벗어나면 종료
+            autoFocus
+          />
+        ) : (
+          <p>{editedContent}</p> // 수정된 내용 표시
+        )}
+      </div>
+    </Card>
+  );
 }

--- a/src/components/RatingStar.tsx
+++ b/src/components/RatingStar.tsx
@@ -2,52 +2,84 @@ import React from "react";
 import { Star } from "lucide-react";
 
 interface Props {
-    rating: number; // 평점
-    size?: number; // 별 크기
-    digit?: number; // 평점 소수점 자리수
-    showScore?: boolean; // 숫자 점수도 같이 보여줄지
+  rating: number; // 평점
+  size?: number; // 별 크기
+  digit?: number; // 평점 소수점 자리수
+  showScore?: boolean; // 숫자 점수도 같이 보여줄지
 }
 
-export default function RatingStar({ rating, size = 20, digit = 1, showScore = true }: Props) {
-    const fill = "#facc15";
-    const borderColor = "#71717a";
+export default function RatingStar({
+  rating,
+  size = 20,
+  digit = 1,
+  showScore = true,
+}: Props) {
+  const fill = "#facc15";
+  const borderColor = "#71717a";
 
-    const fullStars = Math.floor(rating);
-    const fractional = rating - fullStars;
+  const fullStars = Math.floor(rating);
+  const fractional = rating - fullStars;
 
-    const renderStar = (index: number) => {
-        if (index < fullStars) {
-            // 다 채워진 별
-            return <Star key={index} size={size} fill={fill} color={borderColor} strokeWidth={1.5} />;
-        } else if (index === fullStars && fractional > 0) {
-            // 비율로 채워진 별
-            return (
-                <div key={index} style={{ width: size, height: size, position: "relative" }}>
-                    {/* absolute 을 통해 정확히 별 두개를 같은 위치에 그리기 */}
-                    <Star size={size} color={borderColor} strokeWidth={1.5} className="absolute top-0 left-0" />
+  const renderStar = (index: number) => {
+    if (index < fullStars) {
+      // 다 채워진 별
+      return (
+        <Star
+          key={index}
+          size={size}
+          fill={fill}
+          color={borderColor}
+          strokeWidth={1.5}
+        />
+      );
+    } else if (index === fullStars && fractional > 0) {
+      // 비율로 채워진 별
+      return (
+        <div
+          key={index}
+          style={{ width: size, height: size, position: "relative" }}
+        >
+          {/* absolute 을 통해 정확히 별 두개를 같은 위치에 그리기 */}
+          <Star
+            size={size}
+            color={borderColor}
+            strokeWidth={1.5}
+            className="absolute top-0 left-0"
+          />
 
-                    <div
-                        className="absolute top-0 left-0 overflow-hidden"
-                        style={{
-                            // 소숫점 비율을 백분율로 전환하고 width  설정
-                            width: `${fractional * 100}%`,
-                            height: "100%",
-                        }}
-                    >
-                        <Star size={size} fill={fill} color={borderColor} strokeWidth={1.5} />
-                    </div>
-                </div>
-            );
-        } else {
-            // 아예 빈 별
-            return <Star key={index} size={size} color={borderColor} strokeWidth={1.5} />;
-        }
-    };
-
-    return (
-        <div className="flex flex-row gap-2 items-end">
-            <div className="flex flex-row gap-[2px]">{Array.from({ length: 5 }).map((_, index) => renderStar(index))}</div>
-            {showScore && <span className="text-neutral-500 text-xs">{`(${rating.toFixed(digit)})`}</span>}
+          <div
+            className="absolute top-0 left-0 overflow-hidden"
+            style={{
+              // 소숫점 비율을 백분율로 전환하고 width  설정
+              width: `${fractional * 100}%`,
+              height: "100%",
+            }}
+          >
+            <Star
+              size={size}
+              fill={fill}
+              color={borderColor}
+              strokeWidth={1.5}
+            />
+          </div>
         </div>
-    );
+      );
+    } else {
+      // 아예 빈 별
+      return (
+        <Star key={index} size={size} color={borderColor} strokeWidth={1.5} />
+      );
+    }
+  };
+
+  return (
+    <div className="flex flex-row gap-2 items-end">
+      <div className="flex flex-row gap-[2px]">
+        {Array.from({ length: 5 }).map((_, index) => renderStar(index))}
+      </div>
+      {showScore && (
+        <span className="text-neutral-500 text-xs">{`(${rating.toFixed(digit)})`}</span>
+      )}
+    </div>
+  );
 }

--- a/src/components/RestaurantCard.tsx
+++ b/src/components/RestaurantCard.tsx
@@ -79,7 +79,7 @@ export default function RestaurantCard({
           alt={restaurant.name}
           onLoad={() => setImageLoaded(true)}
           onError={() => setImageLoaded(true)}
-          className={`w-full h-40 object-cover transition-opacity duration-500 rounded-md ${
+          className={`w-full h-full object-cover transition-opacity duration-500 rounded-md ${
             imageLoaded ? "opacity-100" : "opacity-0"
           }`}
         />

--- a/src/components/ReviewCard.tsx
+++ b/src/components/ReviewCard.tsx
@@ -25,7 +25,7 @@ export default function ReviewCard({
   editable = false,
 }: Props) {
   const [isEditing, setIsEditing] = useState(false);
-  const [editedComment, setEditedComment] = useState(review.content);
+  const [editedComment, setEditedComment] = useState(review.comment);
 
   return (
     <Card className="w-full flex flex-col gap-3 bg-white border rounded-lg p-4 shadow-sm">
@@ -57,7 +57,7 @@ export default function ReviewCard({
                 variant="outline"
                 className="text-xs px-2 py-1"
                 onClick={() => {
-                  setEditedComment(review.content);
+                  setEditedComment(review.comment);
                   setIsEditing(false);
                 }}
               >
@@ -83,7 +83,7 @@ export default function ReviewCard({
             </div>
           </div>
         ) : (
-          <p className="text-xs w-full break-words">{review.content}</p>
+          <p className="text-xs w-full break-words">{review.comment}</p>
         )}
       </div>
 

--- a/src/entities/restaurant.ts
+++ b/src/entities/restaurant.ts
@@ -26,34 +26,33 @@ export interface Restaurant {
   category: RestaurantCategory;
 }
 
-export enum RestaurantCategory {
+export type RestaurantCategory =
   /// 한식
-  Korean = "Korean",
+  | "Korean"
 
   /// 양식
-  Western = "Western",
+  | "Western"
 
   /// 아시아음식
-  Asia = "Asia",
+  | "Asia"
 
   /// 일식
-  Japanese = "Japanese",
+  | "Japanese"
 
   /// 중식
-  Chinese = "Chinese",
+  | "Chinese"
 
   /// 분식
-  Street = "Street",
+  | "Street"
 
   /// 카페
-  Cafe = "Cafe",
+  | "Cafe"
 
   /// 뷔페
-  Buffet = "Buffet",
+  | "Buffet"
 
   /// 빵집
-  Bakery = "Bakery",
+  | "Bakery"
 
   /// 기타
-  Etc = "Etc",
-}
+  | "Etc";

--- a/src/entities/restaurant.ts
+++ b/src/entities/restaurant.ts
@@ -5,16 +5,16 @@ export interface Restaurant {
   name: string;
 
   /// 식당 대표 사진 URL
-  thumbnailUrl: URL;
+  thumbnailUrl?: URL;
 
   /// 위도
-  latitude: number;
-
-  /// (도로명) 주소
-  address: number;
+  latitude: string;
 
   /// 경도
-  longitude: number;
+  longitude: string;
+
+  /// (도로명) 주소
+  address: string;
 
   /// 연락처
   telephone: string;

--- a/src/entities/review.ts
+++ b/src/entities/review.ts
@@ -1,4 +1,7 @@
 export interface Review {
+  /// 리뷰 id
+  id: number;
+
   /// 식당 ID
   restaurantID: number;
 

--- a/src/lib/static_map.ts
+++ b/src/lib/static_map.ts
@@ -1,0 +1,21 @@
+export default function staticMapUrl(latitude: string, longitude: string): URL {
+  const baseUrl = new URL("https://maps.googleapis.com/maps/api/staticmap");
+
+  const searchParam = {
+    key: import.meta.env.VITE_GCP_KEY,
+    markers: `size:mid,color:red|${latitude},${longitude}`,
+    size: "540x304",
+    scale: "2",
+    center: ``,
+    zoom: "17",
+    language: "ko",
+    region: "KR",
+    style: "feature:poi|element:labels|visibility:off",
+  };
+
+  Object.entries(searchParam).forEach(([key, value]) => {
+    baseUrl.searchParams.append(key, value);
+  });
+
+  return baseUrl;
+}

--- a/src/pages/RestaurantDetail.tsx
+++ b/src/pages/RestaurantDetail.tsx
@@ -1,6 +1,7 @@
 //import MenuCard from "@/components/MenuCard";
 import MenuCardSection from "@/components/MenuCardSection";
 import RatingStar from "@/components/RatingStar";
+import RestaurantCategoryBadge from "@/components/RestaurantCategoryBadge";
 //import RestaurantCategoryBadge from "@/components/RestaurantCategoryBadge";
 import ReviewCard from "@/components/ReviewCard";
 import { Badge } from "@/components/ui/badge";
@@ -9,6 +10,7 @@ import { Textarea } from "@/components/ui/textarea";
 import type { Menu } from "@/entities/menu";
 import { type Restaurant } from "@/entities/restaurant";
 import type { Review } from "@/entities/review";
+import staticMapUrl from "@/lib/static_map";
 import supabase from "@/lib/supabase";
 import { SendIcon, Star } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -68,7 +70,9 @@ export default function RestaurantDetailPage() {
         setRestaurant({
           id: data.id,
           name: data.name,
-          thumbnailUrl: new URL("https://picsum.photos/500"),
+          thumbnailUrl: data.thumbnail_url
+            ? new URL(data.thumbnail_url)
+            : undefined,
           latitude: data.latitude,
           longitude: data.longitude,
           address: data.address,
@@ -111,17 +115,18 @@ export default function RestaurantDetailPage() {
       .eq("restaurant_id", id)
       .order("id", { ascending: false })
       .then(({ data }) => {
-        const newData: ReviewWithNickname[] = data?.map((item) => {
-          return {
-            id: item.id,
-            restaurantID: item.restaurant_id,
-            userId: item.user_id,
-            content: item.content,
-            rating: item.rating,
-            createdAt: item.created_at,
-            nickname: item.users.nickname,
-          };
-        });
+        const newData: ReviewWithNickname[] =
+          data?.map((item) => {
+            return {
+              id: item.id,
+              restaurantID: item.restaurant_id,
+              userId: item.user_id,
+              comment: item.content,
+              rating: item.rating,
+              createdAt: item.created_at,
+              nickname: item.users.nickname,
+            };
+          }) || [];
 
         setReviews(newData);
       });

--- a/src/pages/RestaurantDetail.tsx
+++ b/src/pages/RestaurantDetail.tsx
@@ -159,7 +159,7 @@ export default function RestaurantDetailPage() {
     <div className="flex flex-col gap-6">
       <div className="flex flex-col">
         {restaurant?.category && (
-          <Badge>{restaurant.category === "Korean" && "한식"}</Badge>
+          <RestaurantCategoryBadge category={restaurant.category} />
         )}
         <div className="flex items-end gap-2">
           <h1 className="text-2xl font-bold mt-1 -mb-1">{restaurant?.name}</h1>

--- a/src/pages/RestaurantDetail.tsx
+++ b/src/pages/RestaurantDetail.tsx
@@ -172,7 +172,13 @@ export default function RestaurantDetailPage() {
       </div>
 
       <div className="flex flex-col gap-4">
-        <img className="w-full aspect-video rounded-md border" />
+        <img
+          src={
+            restaurant &&
+            staticMapUrl(restaurant.latitude, restaurant.longitude).toString()
+          }
+          className="w-full aspect-video rounded-md border"
+        />
 
         <div className="w-full flex flex-col gap-2">
           <dl className="flex flex-row gap-6 text-right">

--- a/src/pages/mypage.tsx
+++ b/src/pages/mypage.tsx
@@ -60,11 +60,11 @@ function MyPage() {
         const newData: ReviewWithRestaurant[] =
           reviews?.map((item) => ({
             id: item.id,
-            restaurant_id: item.restaurant_id,
-            user_id: item.user_id,
-            content: item.content,
+            restaurantID: item.restaurant_id,
+            userId: item.user_id,
+            comment: item.content,
             rating: item.rating,
-            created_at: item.created_at,
+            createdAt: item.created_at,
             restaurants: {
               place_name: item.restaurants?.place_name || "알 수 없음",
             },
@@ -96,7 +96,6 @@ function MyPage() {
   }
 
   const displayedComments = showAll ? comments : comments.slice(0, 5);
-  const hasMore = comments.length > 5;
   const toggleLabel = showAll ? "접기" : "더보기";
 
   return (
@@ -163,7 +162,7 @@ function MyPage() {
                 title={review.restaurants?.place_name || "알 수 없음"}
                 onUpdate={(newContent) => {
                   const updated = [...comments];
-                  updated[idx] = { ...updated[idx], content: newContent };
+                  updated[idx] = { ...updated[idx], comment: newContent };
                   setComments(updated);
                 }}
                 onDelete={() => {


### PR DESCRIPTION
# 변경 사항
- 음식점 상세페이지에 구글 지도 이미지 추가
- 음식점 상세페이지에서 카테고리 표시할 때 색상 있는 배지(`RestaurantCategoryBadge`)를 사용하도록 변경
- 기타 오류 수정

<img width="576" height="490" alt="스크린샷 2025-07-30 10 04 50" src="https://github.com/user-attachments/assets/b6c05828-38d4-4354-bb89-1af350dc4e65" />
